### PR TITLE
Fix the "Show table of contents" button (so it can say "Hide ...")

### DIFF
--- a/sass/components/_postinfo.scss
+++ b/sass/components/_postinfo.scss
@@ -126,17 +126,17 @@
         padding-bottom: 1em;
     }
 
-    #toc-cb:checked~.toc-list {
+    #toc-cb:checked ~ .toc-list {
         display: block;
     }
 
     // show/hide text + icon, swapped
-    #toc-cb:checked .extended-fab-btn #show-toc {
+    #toc-cb:checked ~ .toc-button #show-toc {
         display: none;
     }
 
-    #toc-cb:checked .extended-fab-btn #hide-toc {
-        display: block;
+    #toc-cb:checked ~ .toc-button #hide-toc {
+        display: inline-flex;
     }
 
     // get rid of ugly spaces


### PR DESCRIPTION
Before, "Show table of contents" was the text on the button even when the ToC was already shown.

Before: 
<img width="1321" height="337" alt="image" src="https://github.com/user-attachments/assets/590b25e6-1ad5-491e-a802-2c156b3f1174" />

After:
<img width="1321" height="337" alt="image" src="https://github.com/user-attachments/assets/1c8cb728-7406-420f-9feb-b38927ffcf87" />
